### PR TITLE
Fix appveyor github deployment and npm deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,14 +58,13 @@ deploy:
   skip_cleanup: true
   provider: releases
   api_key:
-    secure: GkIbJs8haX3uJ2CNcqmc2F+k+cZrt4SyrAIuYHshZqwXhMjACltO1Fh17MtGTWuRduLJ4iATcm+En4Y/cDYojwUjnFVGWbFE6iEi5tQrQYR4paC42VArYodCFe0mYMC2D05IUZxaVDELDo25Lit8FeLIy4pPpLWEh2mGIT+/8S4=
+    - secure: GkIbJs8haX3uJ2CNcqmc2F+k+cZrt4SyrAIuYHshZqwXhMjACltO1Fh17MtGTWuRduLJ4iATcm+En4Y/cDYojwUjnFVGWbFE6iEi5tQrQYR4paC42VArYodCFe0mYMC2D05IUZxaVDELDo25Lit8FeLIy4pPpLWEh2mGIT+/8S4=
   file_glob: true
-  file: Inexor-*.zip
+  file: /tmp/inexor-build/*nexor-*.zip
   overwrite: true
   on:
     # Deploy only if build was caused by a tag push.
     tags: true
-    all_branches: true
     condition: "$CC = gcc"
     repo: inexor-game/code
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ deploy:
     # push release binaries to GitHub if tag gets created (and create a release draft)
   - provider: GitHub
     auth_token:
-      secure: vIfb9LX3nWCSRefUqY4JJL3hSosnPgKAbmGejFBL+C9GtHJKSuPLU6aMCrR79hPM
+      secure: mILffF4R/yXcj1hSZzZq1HoLe2aScWVuUpCYvkDqLKStI7JHiLt5yb7w2DPo+HF0
     draft: false
     prerelease: true
     # Override files if there are any already.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -220,7 +220,7 @@ create_tag() {
 
 build() {
   (
-    mkcd "/tmp/inexor-build-${build}"
+    mkcd "/tmp/inexor-build"
     conan
     echo "executed conan install "$gitroot" --scope build_all=1 --scope create_package=1 --build=missing -s compiler=$CONAN_COMPILER -s compiler.version=$CONAN_COMPILER_VERSION -s compiler.libcxx=libstdc++11"
     conan install "$gitroot" --scope build_all=1 --scope create_package=1  --build=missing -s compiler="$CONAN_COMPILER" -s compiler.version="$CONAN_COMPILER_VERSION" -s compiler.libcxx="libstdc++11"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -168,12 +168,12 @@ update_package_json()
   local package_version=`echo -e "${INEXOR_VERSION}" | sed "s/^\(.*\)-alpha$/\1/"`
 
   # Replace the version in the file.
-  sed -i -e 's/VERSION_PLACEHOLDER/${package_version}/g' "${package_json_path}"
+  sed -i -e "s/VERSION_PLACEHOLDER/${package_version}/g" "${package_json_path}"
 
   local package_name_extension="linux64"
 
   # Make the package name platform specific
-  sed -i -e 's/PLATFORM_PLACEHOLDER/${package_name_extension}/g' "${package_json_path}"
+  sed -i -e "s/PLATFORM_PLACEHOLDER/${package_name_extension}/g" "${package_json_path}"
 }
 
 publish_to_npm()


### PR DESCRIPTION
This updates the OAuth token for Appveyor so appveyor deployment should be fixed.
Furthermore it __probably__ fixes npm deployment from travis, so that should also be fixed.

whats not fixed in this PR is the deployment of nightly builds to github releases from travis, since travis does not produce any error message, but just does not deploy stuff.
Im not even sure if the package gets created and how the name of that generated package is and where it is.
So i leave that out of this PR and would be happy for any contributions to fix this.